### PR TITLE
speed up revcomp

### DIFF
--- a/benches/revcomp.rs
+++ b/benches/revcomp.rs
@@ -39,13 +39,17 @@ pub fn revcomp(sequence: &mut [u8]) {
 }
 
 pub fn complement(c: &mut u8) {
-    if *c != b'N' {
-        if *c & 2 != 0 {
-            *c ^= 4;
+    let val = *c;
+    let new_val = if val != b'N' {
+        if val & 2 != 0 {
+            val ^ 4
         } else {
-            *c ^= 21;
+            val ^ 21
         }
-    }
+    } else {
+        val
+    };
+    *c = new_val;
 }
 
 // Reverse complement through bit twiddling
@@ -67,7 +71,6 @@ pub fn revcomp_xor_pulp(sequence: &mut [u8]) {
     });
 }
 
-
 fn criterion_benchmark(c: &mut Criterion) {
     let sequence = b"ccaaattgaaagtgagtgtctaatgtattaattagtgaaataatatcttgatatttctttaagggagaattctgataaaagcgtaccgtccccggcTCCTGTGAACTCCCTCCCCCCTTTTACCGCTTGATTGTACTAGAGTCGGTTTGTAGTCATCTTCCAGTTCTAAGCGTGTCACTCATGTGAAGTTAGTAGTTTCGTTTGTAGATCTGGCTAACTAAGGtgattaagttttatataattttttttaagttttgctaaaaatcattttagaagatattttttaaaaatttatgttcttttatgtggtcctttctcaaaatatattgtactgtatatttattataataaagtaccgtatttagttattaaaaatcagCTTGATCGTGTAATAAaaacacaggaaaaaaataaaatttatacaacaaattgtgaaatattaatattacaatgataaaaaataaagttatgaattaaaaatagccTAGGGCCTAGGCTATTAGAAATTGACTTACACATTTGATAACGTGACTCACTATAATGatagattttaatgtattataaaataatttggcaaCCAAAGTACGATTTTATCCATGTTTATGCATACCGCGTCTGACTATAAATCGTTGCATGTGTGGAGTACGTTTTCTTTGATCAGGTCTGTCAAACTTCATCGACAATTTAGCTTTAGACCGGTCTTCAGATAAATTGTTGCATTATGTGGGGGCGTAAGAGAACAGTAAGAACTCAATAATctaatagcctaatttttatttttggacatTTCAAAGCACTCTAAGAGAAAAGTGACACTCAATTAGCTGTAGGATATATGAGTACTGATATAGTTTTTTATGACCCTGttttagactttgaaattttctttcattgtcatTATTTACGGGATTTGTACAAACTGTGCTGGTGCAAGGCTATTTCAGTAACGAGTGTGTCTGATTTATGGCCCAGGAAATTTAAGACTATCTCAATTCTGAATTGAATGGGTTAACAAAGGCAGCAGTTATAAcctgaaataaacaattttaaaataacacaaatgctgtccaaaatattttttaattttataaaatgttatttagccTAATACCAGTAGTAGGTGACCCTAGTACAGCCATCAGTAGCCTATGATTCAGCAATATGATAAGATACAACAAATGTTTAATTGTATTCAAACTAAATATGTAAAaccttgaacattttttttgtcatatacaataaatactattAACAAAATACATTCCTCCGTGCCCCCTCCTCTCCCCTGGAATTAATAATTGctgattttgatttaaattaattttctgatttaagtcatatctttaattataattttgggtCAAATTATCTCACAAACCATgcataatcatattaaaaaaaatgcgctgtatttgtacttttaaaaaaaaatcactactcGTGAGAATCATGAGCAAAATATTCTAAAGTGGAAACGGCACTAAGGTGAACTAAGCAACTTAGTGCAAAActaaatgttagaaaaaatatCCTACACTGCATAAACTATTTTGcaccataaaaaaaagttatgtgtgGGTCTAAAATAATTTGCTGAGCAATTAATGATTTCTAAATGATGCTAAAGTGAACCATTGTAatgttatatgaaaaataaatacacaattaagATCAACACAGTGAAATAACATTGATTGGGTGATTTCAAATGGGGTCTATctgaataatgttttatttaacagtaatttttatttctatcaatttttagtaatatctacaaatattttgttttaggcTGCCAGAAGATCGGCGGTGCAAGGTCAGAGGTGAGATGTTAGGTGGTTCCACCAACTGCACGGAAGAGCTGCCCTCTGTCATTCAAAATTTGACAGGTACAAACAGactatattaaataagaaaaacaaactttttaaaggCTTGACCATTAGTGAATAGGTTATATGCTTATTATTTCCATTTAGCTTTTTGAGACTAGTATGATTAGACAAATCTGCTTAGttcattttcatataatattgaGGAACAAAATTTGTGAGATTTTGCTAAAATAACTTGCTTTGCTTGTTTATAGAGGCacagtaaatcttttttattattattataattttagattttttaatttttaaataagtgataGCATAtgctgtattattaaaaatttaagaactttaaagtatttacagtagcctatattatgtaaTAGGCTAGCCTACTTTATTGTTCGGccaattctttttcttattcatCTTATCATTATTagcagattattatttattactagtttaaaagcacgtcaaaaatgacggacattaatttcttcctccttaggttgctatacttaaatgccggtcaaaaatttaaaagcccgtcaaaaataacagacagcgacatctatggacagaaaatagagagaaacaTCTTCGGGCaacatcggctcgccgaagatggccgagcagtatgacagacatcatgaccaaactttctctttattatagttagattagatagaagattagaagactagtttaaaagcccatca";
     let mut sequence = sequence.to_vec();
@@ -86,8 +89,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     assert!(seq1 == seq2);
     assert!(seq2 == seq3);
     assert!(seq3 == seq4);
-
-
 
     let mut group = c.benchmark_group("RevCmp");
     group.throughput(criterion::Throughput::Bytes(sequence.len() as u64));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,13 +167,17 @@ pub fn translate_sequence(sequence: &[u8]) -> Vec<Amino> {
 }
 
 pub fn complement(c: &mut u8) {
-    if *c != b'N' {
-        if *c & 2 != 0 {
-            *c ^= 4;
+    let val = *c;
+    let new_val = if val != b'N' {
+        if val & 2 != 0 {
+            val ^ 4
         } else {
-            *c ^= 21;
+            val ^ 21
         }
-    }
+    } else {
+        val
+    };
+    *c = new_val;
 }
 
 pub fn revcomp(sequence: &mut [u8]) {


### PR DESCRIPTION
hi! author of `pulp` here. i noticed you were using my library so i took the liberty of checking out your code (hope this is okay). this PR changes a few lines related to `revcomp`, allowing better vectorization and speeding it up by about 10x on my machine